### PR TITLE
Improved result with same/better performance

### DIFF
--- a/util.py
+++ b/util.py
@@ -4,6 +4,9 @@ import sqlite3
 import json
 from matplotlib.ticker import FormatStrFormatter
 
+def isclose(a, b, rel_tol=1e-09, abs_tol=0.0):
+    return abs(a-b) <= max(rel_tol * max(abs(a), abs(b)), abs_tol)
+
 def export2json(filename):
     conn = sqlite3.connect('data/tsp.db')
     cursor = conn.cursor()


### PR DESCRIPTION
I am trying to improve the temperature decrease function. I believe you've also found the formula I use here. Many articles, such as http://what-when-how.com/artificial-intelligence/a-comparison-of-cooling-schedules-for-simulated-annealing-artificial-intelligence/, mention that this popular formula requires prohibitive computing time to halt. Therefore, instead of waiting for its complete end, we can end it ourselves based on the behaviour of cost_best. I think you also found out that at some point cost_best will decrease much more slowly. So we might want to just end there. It is the matter of the balance we would like to take.

I have run some comparisons, just for reference. I simultaneously ran two versions (your original and this modified version) 100 times. Here are the results of both versions.
[original.txt](https://github.com/tnlin/PokemonGo-TSP/files/426286/original.txt)
[modified.txt](https://github.com/tnlin/PokemonGo-TSP/files/426285/modified.txt)

Some facts you might be interested:
- Among 100 runs, modified version has 67 runs that have shorter final distance
- The average of how much those 67 runs win is 103.69m

Sorry that I forgot to time it when I ran the 100 times. So I time another 10 times for each version. Here is what I got:
- Original:
  - real: 3m8.326s / 10 runs
  - user: 3m6.492s / 10 runs
- Modified: 
  - real: 2m53.169s / 10 runs
  - user: 2m51.203s / 10 runs

close #10 
